### PR TITLE
Read the regular expressions the dictionary actually has

### DIFF
--- a/src/tiger_host.c
+++ b/src/tiger_host.c
@@ -194,6 +194,10 @@ int main(int argc, char **argv)
         setvbuf(stderr, NULL, _IONBF, 0);
         return aac_check();
     }
+    if (argc > 1 && !strcmp(argv[1], "--regex-check")) {
+        setvbuf(stderr, NULL, _IONBF, 0);
+        return re_check();
+    }
     if (argc > 1 && !strcmp(argv[1], "--serve")) {
         if (argc < 5) {
             fprintf(stderr, "usage: tiger_host --serve <MacinTalk> "

--- a/src/tiger_host_regex.c
+++ b/src/tiger_host_regex.c
@@ -4,13 +4,15 @@
  * translation unit.
  *
  * Tiger's dictionary matches with the flat SLPD and Cart tables and imports no
- * regex at all.  Leopard's imports regcomp, regexec and regfree, compiles one
- * pattern when the channel opens, and runs it over words afterwards:
+ * regex at all.  Leopard's imports regcomp, regexec and regfree and compiles a
+ * pattern for every rule that needs one, then runs them over words:
  *
- *     ^[[:digit:]]{7,}$          cflags 0x5 = REG_EXTENDED | REG_NOSUB
- *
- * "Seven or more digits and nothing else" -- a telephone number, which is read
- * out digit by digit instead of as a quantity.
+ *     ^[[:digit:]]{7,}$                 a telephone number, read out digit by
+ *                                       digit rather than as a quantity
+ *     ^(K|M|G|T|P)B$                    kilobyte, megabyte, ...
+ *     ^[IVXLCDM]{2,}$                   a roman numeral
+ *     ^([[:upper:]](\.)?)+('?S)?$       an initialism, with or without stops
+ *     ^((JAN(UARY)?)|(FEB(RUARY)?)|...  a month, spelt out or abbreviated
  *
  * Stubbed, this was far worse than absent, because **POSIX regexec returns 0
  * for a match**.  A stub returning 0 therefore said "yes, a phone number" for
@@ -18,122 +20,596 @@
  * out: Leopard said "one, two, three" where Tiger said "one hundred twenty
  * three", and it had done so for as long as this has run.
  *
- * What is implemented below is not a regex engine.  It is a reader for the
- * shape of pattern this framework actually contains -- an optionally anchored
- * single bracket expression with a repetition count -- and it **refuses
- * anything else**, because a matcher that quietly mishandles a construct it
- * does not know would put us straight back where we started.  A refused
- * pattern says so once and then never matches, which is the same answer as
- * having no regex at all and is a defined one.
+ * The first fix read one shape of pattern -- an anchored bracket expression
+ * with a repetition count -- and refused everything else, on the grounds that
+ * a matcher which quietly mishandles a construct it does not know would put us
+ * straight back where we started.  That was the right instinct and the wrong
+ * subset: of the patterns above it accepted exactly one, so a user's log filled
+ * with a hundred refusals per startup and every rule behind them was dead.  KB
+ * stayed "kay bee", "III" stayed "eye eye eye", "Sept." stayed a word.
+ *
+ * So this is the engine, rather than a reader for one shape.  It is a
+ * backtracking matcher over POSIX Extended Regular Expressions -- alternation,
+ * groups, the bracket expression including named classes and ranges, the three
+ * repetition operators and the bounded {n,m} form, both anchors, '.', and the
+ * backslash escape -- which is the whole of ERE except back references, which
+ * ERE does not have, and subexpression reporting, which every call here asks
+ * not to have (REG_NOSUB).  Anything it still cannot parse is refused exactly
+ * as before: said once, and never matched, which is a defined answer.
+ *
+ * REG_ICASE and REG_NEWLINE are honoured.  Basic REs -- regcomp without
+ * REG_EXTENDED -- are refused rather than silently read as Extended, because
+ * the two disagree about what '(' and '{' and '+' mean and guessing wrong is
+ * the failure this file exists to avoid.  Nothing in the framework compiles
+ * one.
+ *
+ * Matching is bounded.  A backtracking engine can be made to take exponential
+ * time by a pattern with nested repetition, and this one runs inside a speech
+ * request, so the step count is capped and a pattern that reaches the cap
+ * reports no match instead of stopping the voice.  A word is a dozen or so
+ * bytes and the real patterns settle in well under a thousand steps.
  */
 #define REG_NOMATCH 1
 
-/* The subset: [^]? '[' '[:' class ':]' ']' repeat '$'?  where repeat is one of
- * {n,} {n,m} {n} + * ? or absent. */
+/* Darwin's cflags, from /usr/include/regex.h -- octal, as they are there. */
+#define TRE_EXTENDED 0001
+#define TRE_ICASE    0002
+#define TRE_NEWLINE  0004
+#define TRE_NOSUB    0010
+
+#define RE_INF       0xffffffffu    /* the 'hi' of an unbounded repetition */
+#define RE_MAX_STEPS 200000         /* the backtracking budget for one match */
+#define RE_MAX_PROGS 256            /* live compiled patterns; see re_slot_for */
+
+enum {
+    RN_EMPTY, RN_CHAR, RN_ANY, RN_SET, RN_BOL, RN_EOL, RN_CAT, RN_ALT, RN_REP
+};
+
 typedef struct {
-    const void *preg;                   /* the caller's regex_t, as a key */
-    int   used;
-    int   anchor_start, anchor_end;
-    int   cls;                          /* 'd', 'a', 'w', 's', 'p', 'x' */
-    unsigned lo, hi;                    /* repetition, hi 0 meaning no limit */
-} re_pat;
+    unsigned char kind;
+    unsigned char ch;               /* RN_CHAR */
+    int a, b;                       /* RN_CAT/RN_ALT children, RN_REP body in a */
+    int set;                        /* RN_SET: index into prog->sets */
+    unsigned lo, hi;                /* RN_REP */
+} re_node;
 
-static re_pat g_re[8];
+typedef struct {
+    re_node *node;
+    int nnode, capnode;
+    unsigned char (*sets)[32];      /* one 256-bit membership map per set */
+    int nset, capset;
+    int root;
+    int icase, newline;
+} re_prog;
 
-static int re_class_of(const char *name, unsigned n)
+/* ---------------------------------------------------------------- building */
+
+static int re_node_new(re_prog *pr, int kind)
 {
-    if (n == 5 && !strncmp(name, "digit", 5)) return 'd';
-    if (n == 5 && !strncmp(name, "alpha", 5)) return 'a';
-    if (n == 5 && !strncmp(name, "alnum", 5)) return 'w';
-    if (n == 5 && !strncmp(name, "space", 5)) return 's';
-    if (n == 5 && !strncmp(name, "punct", 5)) return 'p';
-    if (n == 6 && !strncmp(name, "xdigit", 6)) return 'x';
+    if (pr->nnode == pr->capnode) {
+        int cap = pr->capnode ? pr->capnode * 2 : 16;
+        re_node *grown = (re_node *)realloc(pr->node, (size_t)cap * sizeof(*grown));
+        if (!grown) return -1;
+        pr->node = grown;
+        pr->capnode = cap;
+    }
+    memset(&pr->node[pr->nnode], 0, sizeof(pr->node[0]));
+    pr->node[pr->nnode].kind = (unsigned char)kind;
+    pr->node[pr->nnode].a = pr->node[pr->nnode].b = -1;
+    pr->node[pr->nnode].set = -1;
+    return pr->nnode++;
+}
+
+static int re_set_new(re_prog *pr)
+{
+    if (pr->nset == pr->capset) {
+        int cap = pr->capset ? pr->capset * 2 : 4;
+        unsigned char (*grown)[32] =
+            (unsigned char (*)[32])realloc(pr->sets, (size_t)cap * 32);
+        if (!grown) return -1;
+        pr->sets = grown;
+        pr->capset = cap;
+    }
+    memset(pr->sets[pr->nset], 0, 32);
+    return pr->nset++;
+}
+
+static void re_set_add(unsigned char *set, unsigned c)
+{
+    set[(c & 0xff) >> 3] |= (unsigned char)(1u << (c & 7));
+}
+
+static int re_set_has(const unsigned char *set, unsigned c)
+{
+    return (set[(c & 0xff) >> 3] >> (c & 7)) & 1;
+}
+
+static void re_prog_free(re_prog *pr)
+{
+    if (!pr) return;
+    free(pr->node);
+    free(pr->sets);
+    free(pr);
+}
+
+/* ----------------------------------------------------------------- parsing */
+
+typedef struct {
+    const char *p;
+    re_prog *pr;
+    int bad;
+} re_parse_state;
+
+static int re_parse_alt(re_parse_state *ps);
+
+/* The eleven classes POSIX names, plus the two ranges every locale agrees on.
+ * "C" is the locale here: the framework hands us ASCII words. */
+static int re_class_add(unsigned char *set, const char *name, unsigned n)
+{
+    unsigned c;
+    int which = 0;
+    if      (n == 5 && !strncmp(name, "alpha",  5)) which = 1;
+    else if (n == 5 && !strncmp(name, "digit",  5)) which = 2;
+    else if (n == 5 && !strncmp(name, "alnum",  5)) which = 3;
+    else if (n == 5 && !strncmp(name, "upper",  5)) which = 4;
+    else if (n == 5 && !strncmp(name, "lower",  5)) which = 5;
+    else if (n == 5 && !strncmp(name, "space",  5)) which = 6;
+    else if (n == 5 && !strncmp(name, "punct",  5)) which = 7;
+    else if (n == 5 && !strncmp(name, "print",  5)) which = 8;
+    else if (n == 5 && !strncmp(name, "graph",  5)) which = 9;
+    else if (n == 5 && !strncmp(name, "cntrl",  5)) which = 10;
+    else if (n == 5 && !strncmp(name, "blank",  5)) which = 11;
+    else if (n == 6 && !strncmp(name, "xdigit", 6)) which = 12;
+    else return 0;
+    for (c = 0; c < 256; c++) {
+        int in = 0;
+        switch (which) {
+        case 1:  in = isalpha((int)c)  != 0; break;
+        case 2:  in = c >= '0' && c <= '9';  break;
+        case 3:  in = isalnum((int)c)  != 0; break;
+        case 4:  in = isupper((int)c)  != 0; break;
+        case 5:  in = islower((int)c)  != 0; break;
+        case 6:  in = isspace((int)c)  != 0; break;
+        case 7:  in = ispunct((int)c)  != 0; break;
+        case 8:  in = isprint((int)c)  != 0; break;
+        case 9:  in = isgraph((int)c)  != 0; break;
+        case 10: in = iscntrl((int)c)  != 0; break;
+        case 11: in = c == ' ' || c == '\t';  break;
+        case 12: in = isxdigit((int)c) != 0; break;
+        }
+        if (in) re_set_add(set, c);
+    }
+    return 1;
+}
+
+/* '[' has been consumed.  -> a set index, or -1 with ps->bad set. */
+static int re_parse_bracket(re_parse_state *ps)
+{
+    unsigned char work[32];
+    int negate = 0, first = 1, idx;
+    unsigned c;
+
+    memset(work, 0, sizeof(work));
+    if (*ps->p == '^') { negate = 1; ps->p++; }
+
+    for (;;) {
+        if (!*ps->p) { ps->bad = 1; return -1; }
+        /* A ']' is a literal only as the very first member. */
+        if (*ps->p == ']' && !first) break;
+        first = 0;
+
+        if (ps->p[0] == '[' && (ps->p[1] == ':' || ps->p[1] == '.' || ps->p[1] == '=')) {
+            char kind = ps->p[1];
+            const char close[4] = { kind, ']', 0, 0 };
+            const char *e = strstr(ps->p + 2, close);
+            if (!e) { ps->bad = 1; return -1; }
+            if (kind == ':') {
+                if (!re_class_add(work, ps->p + 2, (unsigned)(e - (ps->p + 2)))) {
+                    ps->bad = 1;                     /* a class we do not know */
+                    return -1;
+                }
+            } else {
+                /* [.x.] and [=x=]: in the C locale a collating element and an
+                 * equivalence class are each just the character itself. */
+                if (e != ps->p + 3) { ps->bad = 1; return -1; }
+                re_set_add(work, (unsigned char)ps->p[2]);
+            }
+            ps->p = e + 2;
+            continue;
+        }
+
+        c = (unsigned char)*ps->p++;
+        /* A range, unless the '-' is last and so a literal. */
+        if (*ps->p == '-' && ps->p[1] && ps->p[1] != ']') {
+            unsigned hi = (unsigned char)ps->p[1];
+            if (hi < c) { ps->bad = 1; return -1; }
+            for (; c <= hi; c++) re_set_add(work, c);
+            ps->p += 2;
+            continue;
+        }
+        re_set_add(work, c);
+    }
+    ps->p++;                                          /* the closing ']' */
+
+    if (ps->pr->icase) {
+        for (c = 'a'; c <= 'z'; c++) {
+            if (re_set_has(work, c)) re_set_add(work, c - 'a' + 'A');
+            if (re_set_has(work, c - 'a' + 'A')) re_set_add(work, c);
+        }
+    }
+    if (negate) {
+        int i;
+        for (i = 0; i < 32; i++) work[i] = (unsigned char)~work[i];
+        /* With REG_NEWLINE a negated bracket does not match a newline. */
+        if (ps->pr->newline) work['\n' >> 3] &= (unsigned char)~(1u << ('\n' & 7));
+    }
+
+    if ((idx = re_set_new(ps->pr)) < 0) { ps->bad = 1; return -1; }
+    memcpy(ps->pr->sets[idx], work, 32);
+    return idx;
+}
+
+static int re_lit(re_parse_state *ps, unsigned char c)
+{
+    int n = re_node_new(ps->pr, RN_CHAR);
+    if (n < 0) { ps->bad = 1; return -1; }
+    ps->pr->node[n].ch = c;
+    return n;
+}
+
+static int re_parse_atom(re_parse_state *ps)
+{
+    int n;
+    switch (*ps->p) {
+    case '(': {
+        ps->p++;
+        n = re_parse_alt(ps);
+        if (ps->bad) return -1;
+        if (*ps->p != ')') { ps->bad = 1; return -1; }
+        ps->p++;
+        return n;
+    }
+    case '[':
+        ps->p++;
+        n = re_parse_bracket(ps);
+        if (n < 0) return -1;
+        {
+            int node = re_node_new(ps->pr, RN_SET);
+            if (node < 0) { ps->bad = 1; return -1; }
+            ps->pr->node[node].set = n;
+            return node;
+        }
+    case '.':
+        ps->p++;
+        n = re_node_new(ps->pr, RN_ANY);
+        if (n < 0) ps->bad = 1;
+        return n;
+    case '^':
+        ps->p++;
+        n = re_node_new(ps->pr, RN_BOL);
+        if (n < 0) ps->bad = 1;
+        return n;
+    case '$':
+        ps->p++;
+        n = re_node_new(ps->pr, RN_EOL);
+        if (n < 0) ps->bad = 1;
+        return n;
+    case '\\':
+        ps->p++;
+        if (!*ps->p) { ps->bad = 1; return -1; }
+        return re_lit(ps, (unsigned char)*ps->p++);
+    case ')':
+    case '\0':
+        ps->bad = 1;
+        return -1;
+    case '*':
+    case '+':
+    case '?':
+        /* A repetition with nothing to repeat.  POSIX leaves this undefined
+         * and this refuses it, rather than pick a meaning. */
+        ps->bad = 1;
+        return -1;
+    default:
+        return re_lit(ps, (unsigned char)*ps->p++);
+    }
+}
+
+/* "{2,}", "{3}", "{1,3}" -- and not "{", which is then an ordinary character.
+ * -> 1 if `s` opens a well formed interval, with the bounds in *lo and *hi and
+ * *len the length including both braces. */
+static int re_interval(const char *s, unsigned *lo, unsigned *hi, int *len)
+{
+    const char *p = s + 1;
+    unsigned n;
+    if (*s != '{' || *p < '0' || *p > '9') return 0;
+    for (n = 0; *p >= '0' && *p <= '9'; p++) n = n * 10 + (unsigned)(*p - '0');
+    *lo = n;
+    if (*p == ',') {
+        p++;
+        if (*p == '}') *hi = RE_INF;
+        else {
+            if (*p < '0' || *p > '9') return 0;
+            for (n = 0; *p >= '0' && *p <= '9'; p++) n = n * 10 + (unsigned)(*p - '0');
+            *hi = n;
+        }
+    } else *hi = *lo;
+    if (*p != '}') return 0;
+    if (*hi != RE_INF && *hi < *lo) return 0;
+    *len = (int)(p - s) + 1;
+    return 1;
+}
+
+static int re_parse_rep(re_parse_state *ps)
+{
+    int a = re_parse_atom(ps), rep;
+    unsigned lo, hi;
+    int len;
+    if (ps->bad) return -1;
+    for (;;) {
+        if (*ps->p == '*')      { lo = 0; hi = RE_INF; ps->p++; }
+        else if (*ps->p == '+') { lo = 1; hi = RE_INF; ps->p++; }
+        else if (*ps->p == '?') { lo = 0; hi = 1;      ps->p++; }
+        else if (re_interval(ps->p, &lo, &hi, &len)) { ps->p += len; }
+        else break;
+        if ((rep = re_node_new(ps->pr, RN_REP)) < 0) { ps->bad = 1; return -1; }
+        ps->pr->node[rep].a  = a;
+        ps->pr->node[rep].lo = lo;
+        ps->pr->node[rep].hi = hi;
+        a = rep;
+    }
+    return a;
+}
+
+static int re_parse_cat(re_parse_state *ps)
+{
+    int a = -1;
+    while (*ps->p && *ps->p != '|' && *ps->p != ')') {
+        int r = re_parse_rep(ps), cat;
+        if (ps->bad) return -1;
+        if (a < 0) { a = r; continue; }
+        if ((cat = re_node_new(ps->pr, RN_CAT)) < 0) { ps->bad = 1; return -1; }
+        ps->pr->node[cat].a = a;
+        ps->pr->node[cat].b = r;
+        a = cat;
+    }
+    if (a < 0) {
+        if ((a = re_node_new(ps->pr, RN_EMPTY)) < 0) ps->bad = 1;
+    }
+    return a;
+}
+
+static int re_parse_alt(re_parse_state *ps)
+{
+    int a = re_parse_cat(ps);
+    if (ps->bad) return -1;
+    while (*ps->p == '|') {
+        int b, alt;
+        ps->p++;
+        b = re_parse_cat(ps);
+        if (ps->bad) return -1;
+        if ((alt = re_node_new(ps->pr, RN_ALT)) < 0) { ps->bad = 1; return -1; }
+        ps->pr->node[alt].a = a;
+        ps->pr->node[alt].b = b;
+        a = alt;
+    }
+    return a;
+}
+
+static re_prog *re_compile(const char *pattern, int cflags)
+{
+    re_parse_state ps;
+    re_prog *pr;
+    if (!pattern) return NULL;
+    if (!(cflags & TRE_EXTENDED)) return NULL;     /* see the header comment */
+    if (!(pr = (re_prog *)calloc(1, sizeof(*pr)))) return NULL;
+    pr->icase   = (cflags & TRE_ICASE)   != 0;
+    pr->newline = (cflags & TRE_NEWLINE) != 0;
+    ps.p = pattern;
+    ps.pr = pr;
+    ps.bad = 0;
+    pr->root = re_parse_alt(&ps);
+    if (ps.bad || *ps.p) { re_prog_free(pr); return NULL; }
+    return pr;
+}
+
+/* ---------------------------------------------------------------- matching */
+
+/* What is left to do after the node in hand.  A frame is either "run this
+ * node" or "you have just finished iteration `count` of this repetition",
+ * which is what lets a repetition backtrack into its own body. */
+typedef struct re_cont {
+    int node;                       /* RN_* node, when rep < 0 */
+    int rep;                        /* the RN_REP node, when >= 0 */
+    unsigned count;
+    const unsigned char *mark;      /* where that iteration began */
+    const struct re_cont *next;
+} re_cont;
+
+typedef struct {
+    const re_prog *pr;
+    const unsigned char *base;
+    unsigned long steps;
+    int spent;                      /* the step budget ran out */
+} re_ctx;
+
+static int re_run(re_ctx *c, int node, const unsigned char *s, const re_cont *k);
+
+static int re_cont_run(re_ctx *c, const re_cont *k, const unsigned char *s);
+
+static int re_eq(const re_ctx *c, unsigned char a, unsigned char b)
+{
+    if (a == b) return 1;
+    return c->pr->icase && tolower((int)a) == tolower((int)b);
+}
+
+static int re_rep(re_ctx *c, int rep, unsigned count, const unsigned char *mark,
+                  const unsigned char *s, const re_cont *k)
+{
+    const re_node *n = &c->pr->node[rep];
+    re_cont frame;
+
+    if (c->spent) return 0;
+    /* An iteration that consumed nothing cannot be improved on by doing it
+     * again, and doing it again is how a body that matches the empty string
+     * spins forever.  Any shortfall against `lo` can be padded with more of
+     * those same empty iterations, so the answer either way is to go on. */
+    if (count > 0 && s == mark) return re_cont_run(c, k, s);
+
+    if (n->hi == RE_INF || count < n->hi) {
+        frame.node  = -1;
+        frame.rep   = rep;
+        frame.count = count + 1;
+        frame.mark  = s;
+        frame.next  = k;
+        if (re_run(c, n->a, s, &frame)) return 1;
+        if (c->spent) return 0;
+    }
+    if (count >= n->lo) return re_cont_run(c, k, s);
     return 0;
 }
 
-static int re_in_class(int cls, unsigned char c)
+static int re_cont_run(re_ctx *c, const re_cont *k, const unsigned char *s)
 {
-    switch (cls) {
-    case 'd': return c >= '0' && c <= '9';
-    case 'a': return isalpha(c) != 0;
-    case 'w': return isalnum(c) != 0;
-    case 's': return isspace(c) != 0;
-    case 'p': return ispunct(c) != 0;
-    case 'x': return isxdigit(c) != 0;
+    if (c->spent) return 0;
+    if (!k) return 1;                               /* nothing left: a match */
+    if (k->rep >= 0) return re_rep(c, k->rep, k->count, k->mark, s, k->next);
+    return re_run(c, k->node, s, k->next);
+}
+
+static int re_run(re_ctx *c, int node, const unsigned char *s, const re_cont *k)
+{
+    const re_node *n;
+    re_cont frame;
+
+    if (c->spent) return 0;
+    if (++c->steps > RE_MAX_STEPS) { c->spent = 1; return 0; }
+    n = &c->pr->node[node];
+
+    switch (n->kind) {
+    case RN_EMPTY:
+        return re_cont_run(c, k, s);
+    case RN_CHAR:
+        return (*s && re_eq(c, *s, n->ch)) ? re_cont_run(c, k, s + 1) : 0;
+    case RN_ANY:
+        if (!*s) return 0;
+        if (c->pr->newline && *s == '\n') return 0;
+        return re_cont_run(c, k, s + 1);
+    case RN_SET:
+        return (*s && re_set_has(c->pr->sets[n->set], *s))
+             ? re_cont_run(c, k, s + 1) : 0;
+    case RN_BOL:
+        if (s == c->base || (c->pr->newline && s[-1] == '\n'))
+            return re_cont_run(c, k, s);
+        return 0;
+    case RN_EOL:
+        if (!*s || (c->pr->newline && *s == '\n'))
+            return re_cont_run(c, k, s);
+        return 0;
+    case RN_CAT:
+        frame.node = n->b;
+        frame.rep  = -1;
+        frame.count = 0;
+        frame.mark = NULL;
+        frame.next = k;
+        return re_run(c, n->a, s, &frame);
+    case RN_ALT:
+        if (re_run(c, n->a, s, k)) return 1;
+        return re_run(c, n->b, s, k);
+    case RN_REP:
+        return re_rep(c, node, 0, NULL, s, k);
     }
     return 0;
 }
 
-/* -> 1 if the whole pattern was understood and `out` describes it. */
-static int re_parse(const char *p, re_pat *out)
+static int re_search(const re_prog *pr, const char *string)
 {
-    const char *e;
-    unsigned n;
-    if (!p) return 0;
-    memset(out, 0, sizeof(*out));
-    out->lo = out->hi = 1;
-    if (*p == '^') { out->anchor_start = 1; p++; }
-    if (strncmp(p, "[[:", 3) != 0) return 0;
-    p += 3;
-    e = strstr(p, ":]]");
-    if (!e) return 0;
-    out->cls = re_class_of(p, (unsigned)(e - p));
-    if (!out->cls) return 0;
-    p = e + 3;
-    if (*p == '{') {
-        p++;
-        if (*p < '0' || *p > '9') return 0;
-        for (n = 0; *p >= '0' && *p <= '9'; p++) n = n * 10 + (unsigned)(*p - '0');
-        out->lo = n;
-        if (*p == ',') {
-            p++;
-            if (*p == '}') out->hi = 0;                 /* {n,} -- no limit */
-            else {
-                for (n = 0; *p >= '0' && *p <= '9'; p++)
-                    n = n * 10 + (unsigned)(*p - '0');
-                out->hi = n;
-            }
-        } else out->hi = out->lo;
-        if (*p != '}') return 0;
-        p++;
-    } else if (*p == '+') { out->lo = 1; out->hi = 0; p++; }
-    else if (*p == '*')   { out->lo = 0; out->hi = 0; p++; }
-    else if (*p == '?')   { out->lo = 0; out->hi = 1; p++; }
-    if (*p == '$') { out->anchor_end = 1; p++; }
-    return *p == 0;
+    const unsigned char *base = (const unsigned char *)string;
+    const unsigned char *s;
+    re_ctx c;
+    c.pr = pr;
+    c.base = base;
+    c.steps = 0;
+    c.spent = 0;
+    /* REG_NOSUB: whether a match exists anywhere is the whole question, so the
+     * first start position that works is the answer.  A '^' inside the pattern
+     * fails every later start on its own. */
+    for (s = base; ; s++) {
+        if (re_run(&c, pr->root, s, NULL)) return 1;
+        if (c.spent || !*s) return 0;
+    }
 }
 
-static re_pat *re_find(const void *preg)
-{
-    int i;
-    for (i = 0; i < 8; i++)
-        if (g_re[i].used && g_re[i].preg == preg) return &g_re[i];
-    return NULL;
-}
+/* --------------------------------------------------------------- the shims */
 
 /* Nothing is written through `preg`.  A Darwin i386 regex_t is four words --
  * re_magic, re_nsub, re_endp, re_g -- and clearing a generous 64 bytes over it
  * walked off the end of the caller's stack slot and took the process down on
- * the first utterance.  The pattern is kept here and keyed by that pointer
- * instead, so the caller's memory is never touched. */
+ * the first utterance.  The compiled pattern is kept here and keyed by that
+ * pointer instead, so the caller's memory is never touched. */
+typedef struct {
+    const void *preg;               /* NULL once freed: the slot is spare */
+    re_prog *prog;                  /* NULL for a pattern we would not read */
+} re_slot;
+
+static re_slot *g_re;
+static int g_re_n, g_re_cap;
+
+static re_slot *re_find(const void *preg)
+{
+    int i;
+    if (!preg) return NULL;
+    for (i = 0; i < g_re_n; i++)
+        if (g_re[i].preg == preg) return &g_re[i];
+    return NULL;
+}
+
+/* -> the slot for `preg`: its own if it has one, otherwise one freed earlier,
+ * otherwise a new one.  The table only grows to RE_MAX_PROGS; past that the
+ * oldest is taken, on the grounds that a caller which holds that many patterns
+ * at once is not going to be helped by us running out of memory instead. */
+static re_slot *re_slot_for(const void *preg)
+{
+    re_slot *slot = re_find(preg);
+    int i;
+    if (slot) {
+        re_prog_free(slot->prog);
+        slot->prog = NULL;
+        return slot;
+    }
+    for (i = 0; i < g_re_n; i++)
+        if (!g_re[i].preg) { g_re[i].preg = preg; return &g_re[i]; }
+    if (g_re_n == g_re_cap && g_re_cap < RE_MAX_PROGS) {
+        int cap = g_re_cap ? g_re_cap * 2 : 16;
+        re_slot *grown;
+        if (cap > RE_MAX_PROGS) cap = RE_MAX_PROGS;
+        grown = (re_slot *)realloc(g_re, (size_t)cap * sizeof(*grown));
+        if (grown) { g_re = grown; g_re_cap = cap; }
+    }
+    if (g_re_n < g_re_cap) {
+        g_re[g_re_n].preg = preg;
+        g_re[g_re_n].prog = NULL;
+        return &g_re[g_re_n++];
+    }
+    if (g_re_n == 0) return NULL;
+    re_prog_free(g_re[0].prog);
+    memmove(&g_re[0], &g_re[1], (size_t)(g_re_n - 1) * sizeof(g_re[0]));
+    g_re[g_re_n - 1].preg = preg;
+    g_re[g_re_n - 1].prog = NULL;
+    return &g_re[g_re_n - 1];
+}
+
 static int __cdecl sh_regcomp(void *preg, const char *pattern, int cflags)
 {
-    re_pat parsed;
-    int i, ok = re_parse(pattern, &parsed);
-    if (!ok)
+    re_prog *prog = re_compile(pattern, cflags);
+    re_slot *slot;
+    if (!prog)
         fprintf(stderr, "tiger_host: SpeechDictionary compiled a regular "
                         "expression this does not implement, so it will never "
                         "match: %s\n", pattern ? pattern : "(null)");
-    for (i = 0; i < 8; i++)
-        if (!g_re[i].used || g_re[i].preg == preg) break;
-    if (i < 8) {
-        if (ok) { g_re[i] = parsed; }
-        else    { memset(&g_re[i], 0, sizeof(g_re[i])); }
-        g_re[i].preg = preg;
-        g_re[i].used = ok ? 1 : 0;      /* unparsed patterns stay unmatched */
-    }
+    if ((slot = re_slot_for(preg))) slot->prog = prog;
+    else re_prog_free(prog);
     if (g_verbose)
-        printf("  [re] %s (cflags 0x%x): %s\n", ok ? "compiled" : "REFUSED",
+        printf("  [re] %s (cflags 0x%x): %s\n", prog ? "compiled" : "REFUSED",
                cflags, pattern ? pattern : "(null)");
     return 0;                            /* the compile itself always succeeds */
 }
@@ -143,27 +619,215 @@ static int __cdecl sh_regcomp(void *preg, const char *pattern, int cflags)
 static int __cdecl sh_regexec(const void *preg, const char *string,
                               unsigned nmatch, void *pmatch, int eflags)
 {
-    const re_pat *r = re_find(preg);
-    const unsigned char *s = (const unsigned char *)string;
-    unsigned start;
+    const re_slot *slot = re_find(preg);
     (void)eflags; (void)nmatch; (void)pmatch;   /* every use here is REG_NOSUB */
-    if (!r || !s) return REG_NOMATCH;
-    /* Try each starting position, which for the anchored form is only the
-     * first.  A run is a match when it is long enough, short enough, and --
-     * if the pattern ends in '$' -- reaches the end of the string. */
-    for (start = 0; ; start++) {
-        unsigned n = 0;
-        while (s[start + n] && re_in_class(r->cls, s[start + n])) n++;
-        if (n >= r->lo && (!r->hi || n <= r->hi) &&
-            (!r->anchor_end || !s[start + n]))
-            return 0;
-        if (r->anchor_start || !s[start]) break;
-    }
-    return REG_NOMATCH;
+    if (!slot || !slot->prog || !string) return REG_NOMATCH;
+    return re_search(slot->prog, string) ? 0 : REG_NOMATCH;
 }
 
 static void __cdecl sh_regfree(void *preg)
 {
-    re_pat *r = re_find(preg);
-    if (r) r->used = 0;
+    re_slot *slot = re_find(preg);
+    if (!slot) return;
+    re_prog_free(slot->prog);
+    slot->prog = NULL;
+    slot->preg = NULL;
+}
+
+/* --------------------------------------------------------------- self test */
+
+/* `tiger_host --regex-check` -- the same shape as --aac-check, and for the
+ * same reason: a matcher is easy to get subtly wrong and impossible to see
+ * being wrong from the outside, where its only trace is a word pronounced
+ * oddly.  Every pattern below with a name is one this framework really
+ * compiles, taken from a log; the expectations were computed independently.
+ */
+static const char RE_MONTH[] =
+    "^((JAN(UARY)?)|(FEB(RUARY)?)|(MAR(CH)?)|(APR(IL)?)|(MAY)|(JUN(E)?)"
+    "|(JUL(Y)?)|(AUG(UST)?)|(SEP(TEMBER)?)|(OCT(OBER)?)|(NOV(EMBER)?)"
+    "|(DEC(EMBER)?))$";
+static const char RE_INITIALISM[] =
+    "^([[:upper:]](\\.)?)+('(([[:upper:]](\\.)?)+)?)?$";
+static const char RE_HYPHEN_INITIALISM[] =
+    "^([[:upper:]](\\.)?)+('(([[:upper:]](\\.)?)+)?)?"
+    "(-([[:upper:]](\\.)?)+('(([[:upper:]](\\.)?)+)?)?)+('?S)?$";
+static const char RE_QUANTITY[] =
+    "^(([[:digit:]]{1,3}(,[[:digit:]]{3})*)|([[:digit:]]+(\\.[[:digit:]]+)?)"
+    "|(([[:digit:]]+)?\\.[[:digit:]]+))[[:upper:]]+$";
+
+static int re_check(void)
+{
+    static const struct { const char *pat, *subj; int icase, want; } cases[] = {
+        { "^[[:digit:]]{7,}$"     , "1234567"       , 0, 1 },
+        { "^[[:digit:]]{7,}$"     , "123456"        , 0, 0 },
+        { "^[[:digit:]]{7,}$"     , "12345678"      , 0, 1 },
+        { "^[[:digit:]]{7,}$"     , "123456a"       , 0, 0 },
+        { "^[[:digit:]]{7,}$"     , ""              , 0, 0 },
+        { "^[[:digit:]]{7,}$"     , "a1234567"      , 0, 0 },
+        { RE_MONTH                , "JAN"           , 0, 1 },
+        { RE_MONTH                , "JANUARY"       , 0, 1 },
+        { RE_MONTH                , "MAY"           , 0, 1 },
+        { RE_MONTH                , "MAYBE"         , 0, 0 },
+        { RE_MONTH                , "SEPTEMBER"     , 0, 1 },
+        { RE_MONTH                , "SEP"           , 0, 1 },
+        { RE_MONTH                , "DEC"           , 0, 1 },
+        { RE_MONTH                , "DECEMBERS"     , 0, 0 },
+        { RE_MONTH                , "FEBRUARY"      , 0, 1 },
+        { RE_MONTH                , "JUL"           , 0, 1 },
+        { RE_MONTH                , "JULY"          , 0, 1 },
+        { RE_MONTH                , "MARCH"         , 0, 1 },
+        { RE_MONTH                , "MAR"           , 0, 1 },
+        { RE_MONTH                , "OCT"           , 0, 1 },
+        { RE_MONTH                , "APRIL"         , 0, 1 },
+        { RE_MONTH                , "JUNE"          , 0, 1 },
+        { RE_MONTH                , "AUG"           , 0, 1 },
+        { RE_MONTH                , "NOV"           , 0, 1 },
+        { RE_MONTH                , "XAN"           , 0, 0 },
+        { RE_HYPHEN_INITIALISM    , "U.S.-BASED"    , 0, 1 },
+        { RE_HYPHEN_INITIALISM    , "U.S."          , 0, 0 },
+        { RE_HYPHEN_INITIALISM    , "AT&T"          , 0, 0 },
+        { RE_HYPHEN_INITIALISM    , "A-B"           , 0, 1 },
+        { RE_HYPHEN_INITIALISM    , "A.B.-C.D."     , 0, 1 },
+        { RE_HYPHEN_INITIALISM    , "US-A'S"        , 0, 1 },
+        { RE_HYPHEN_INITIALISM    , "ABC"           , 0, 0 },
+        { "^[[:digit:]]+ISH$"     , "20ISH"         , 0, 1 },
+        { "^[[:digit:]]+ISH$"     , "20ish"         , 0, 0 },
+        { "^[[:digit:]]+ISH$"     , "ISH"           , 0, 0 },
+        { "^[[:digit:]]+ISH$"     , "1ISH"          , 0, 1 },
+        { RE_QUANTITY             , "1,234MB"       , 0, 1 },
+        { RE_QUANTITY             , "5MB"           , 0, 1 },
+        { RE_QUANTITY             , "12.5GB"        , 0, 1 },
+        { RE_QUANTITY             , ".5KB"          , 0, 1 },
+        { RE_QUANTITY             , "1234KB"        , 0, 1 },
+        { RE_QUANTITY             , "5M"            , 0, 1 },
+        { RE_QUANTITY             , "MB"            , 0, 0 },
+        { "^[IVXLCDM]{2,}$"       , "III"           , 0, 1 },
+        { "^[IVXLCDM]{2,}$"       , "IV"            , 0, 1 },
+        { "^[IVXLCDM]{2,}$"       , "I"             , 0, 0 },
+        { "^[IVXLCDM]{2,}$"       , "XIV"           , 0, 1 },
+        { "^[IVXLCDM]{2,}$"       , "IIIA"          , 0, 0 },
+        { "^[IVXLCDM]{2,}$"       , "MCMLXXXIV"     , 0, 1 },
+        { "^[[:upper:]]+&[[:upper:]]+$", "AT&T"          , 0, 1 },
+        { "^[[:upper:]]+&[[:upper:]]+$", "A&B"           , 0, 1 },
+        { "^[[:upper:]]+&[[:upper:]]+$", "AT&"           , 0, 0 },
+        { "^[[:upper:]]+&[[:upper:]]+$", "&B"            , 0, 0 },
+        { "^[[:upper:]]+&[[:upper:]]+$", "AB&CD"         , 0, 1 },
+        { "^(K|M|G|T|P)B$"        , "KB"            , 0, 1 },
+        { "^(K|M|G|T|P)B$"        , "MB"            , 0, 1 },
+        { "^(K|M|G|T|P)B$"        , "GB"            , 0, 1 },
+        { "^(K|M|G|T|P)B$"        , "TB"            , 0, 1 },
+        { "^(K|M|G|T|P)B$"        , "PB"            , 0, 1 },
+        { "^(K|M|G|T|P)B$"        , "XB"            , 0, 0 },
+        { "^(K|M|G|T|P)B$"        , "K"             , 0, 0 },
+        { "^(K|M|G|T|P)B$"        , "KBB"           , 0, 0 },
+        { "^[[:digit:]]{3}\\.[[:digit:]]{3}\\.[[:digit:]]{4}$", "555.123.4567"  , 0, 1 },
+        { "^[[:digit:]]{3}\\.[[:digit:]]{3}\\.[[:digit:]]{4}$", "5551234567"    , 0, 0 },
+        { "^[[:digit:]]{3}\\.[[:digit:]]{3}\\.[[:digit:]]{4}$", "555.123.456"   , 0, 0 },
+        { RE_INITIALISM           , "U.S."          , 0, 1 },
+        { RE_INITIALISM           , "USA"           , 0, 1 },
+        { RE_INITIALISM           , "U.S.A."        , 0, 1 },
+        { RE_INITIALISM           , "U.S.A"         , 0, 1 },
+        { RE_INITIALISM           , "us"            , 0, 0 },
+        { "abc"                   , "xxabcxx"       , 0, 1 },
+        { "abc"                   , "abd"           , 0, 0 },
+        { "^abc$"                 , "abc"           , 0, 1 },
+        { "^abc$"                 , "abcd"          , 0, 0 },
+        { "a.c"                   , "abc"           , 0, 1 },
+        { "a.c"                   , "ac"            , 0, 0 },
+        { "a.*c"                  , "abbbc"         , 0, 1 },
+        { "a.*c"                  , "ac"            , 0, 1 },
+        { "a+"                    , "b"             , 0, 0 },
+        { "a+"                    , "baaa"          , 0, 1 },
+        { "colou?r"               , "color"         , 0, 1 },
+        { "colou?r"               , "colour"        , 0, 1 },
+        { "colou?r"               , "colouur"       , 0, 0 },
+        { "^(a|b)+$"              , "abab"          , 0, 1 },
+        { "^(a|b)+$"              , "abc"           , 0, 0 },
+        { "^(ab|a)(c|bc)$"        , "abc"           , 0, 1 },
+        { "^a{3}$"                , "aaa"           , 0, 1 },
+        { "^a{3}$"                , "aa"            , 0, 0 },
+        { "^a{2,3}$"              , "aaaa"          , 0, 0 },
+        { "^a{2,}$"               , "aaaaa"         , 0, 1 },
+        { "^[a-c]+$"              , "abcabc"        , 0, 1 },
+        { "^[^a-c]+$"             , "xyz"           , 0, 1 },
+        { "^[^a-c]+$"             , "xayz"          , 0, 0 },
+        { "^[]a]+$"               , "]a]"           , 0, 1 },
+        { "^[a-]+$"               , "a-a"           , 0, 1 },
+        { "^[.]$"                 , "."             , 0, 1 },
+        { "^[.]$"                 , "x"             , 0, 0 },
+        { "^\\.$"                 , "."             , 0, 1 },
+        { "^\\.$"                 , "x"             , 0, 0 },
+        { "^a\\+b$"               , "a+b"           , 0, 1 },
+        { "^(a*)*$"               , "aaa"           , 0, 1 },
+        { "^(a*)*b$"              , "aaab"          , 0, 1 },
+        { "^(|a)b$"               , "b"             , 0, 1 },
+        { "^$"                    , ""              , 0, 1 },
+        { "^$"                    , "a"             , 0, 0 },
+        { "x{"                    , "x{"            , 0, 1 },
+        { "^[[:alpha:][:digit:]]+$", "ab12"          , 0, 1 },
+        { "^[[:space:]]+$"        , " \t"           , 0, 1 },
+        { "^[[:punct:]]+$"        , "!?."           , 0, 1 },
+        { "^[[:xdigit:]]+$"       , "dEadBeef99"    , 0, 1 },
+        { "^[[:lower:]]+$"        , "abc"           , 0, 1 },
+        { "^[[:lower:]]+$"        , "aBc"           , 0, 0 },
+        { "^abc$"                 , "ABC"           , 1, 1 },
+        { "^[a-c]+$"              , "ABC"           , 1, 1 },
+        { "^[^a-c]+$"             , "ABC"           , 1, 0 },
+    };
+    /* Patterns that are not ERE at all, and must be refused rather than
+     * guessed at.  A refusal is what puts a line in the user's log, so it has
+     * to stay rare and stay honest. */
+    static const char *bad[] = {
+        "(",  ")",  "a)",  "[a",  "[[:nosuch:]]",  "*a",  "a|*",  "[z-a]",
+    };
+    int i, fails = 0;
+    for (i = 0; i < (int)(sizeof(cases) / sizeof(cases[0])); i++) {
+        re_prog *pr = re_compile(cases[i].pat,
+                                 TRE_EXTENDED | TRE_NOSUB |
+                                 (cases[i].icase ? TRE_ICASE : 0));
+        int got;
+        if (!pr) {
+            printf("FAIL  refused: %s\n", cases[i].pat);
+            fails++;
+            continue;
+        }
+        got = re_search(pr, cases[i].subj);
+        if (got != cases[i].want) {
+            printf("FAIL  %s  on \"%s\"%s: wanted %d, got %d\n",
+                   cases[i].pat, cases[i].subj,
+                   cases[i].icase ? " (icase)" : "", cases[i].want, got);
+            fails++;
+        }
+        re_prog_free(pr);
+    }
+    for (i = 0; i < (int)(sizeof(bad) / sizeof(bad[0])); i++) {
+        re_prog *pr = re_compile(bad[i], TRE_EXTENDED | TRE_NOSUB);
+        if (pr) {
+            printf("FAIL  accepted a pattern it should refuse: %s\n", bad[i]);
+            re_prog_free(pr);
+            fails++;
+        }
+    }
+    /* A basic RE is refused: '(' and '{' and '+' mean other things there. */
+    {
+        re_prog *pr = re_compile("^a$", TRE_NOSUB);
+        if (pr) { printf("FAIL  accepted a basic RE\n"); re_prog_free(pr); fails++; }
+    }
+    /* Nested unbounded repetition over a subject that cannot match is the
+     * classic way to make a backtracking engine take forever.  This must come
+     * back, and come back saying no. */
+    {
+        re_prog *pr = re_compile("^(a*)*b$", TRE_EXTENDED | TRE_NOSUB);
+        if (!pr) { printf("FAIL  refused the backtracking probe\n"); fails++; }
+        else {
+            if (re_search(pr, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaX")) {
+                printf("FAIL  the backtracking probe matched\n");
+                fails++;
+            }
+            re_prog_free(pr);
+        }
+    }
+    printf("regex: %d cases, %d failures\n",
+           (int)(sizeof(cases) / sizeof(cases[0])), fails);
+    return fails ? 1 : 0;
 }


### PR DESCRIPTION
Leopard's `SpeechDictionary` compiles a pattern for every rule that needs one. The shim in `tiger_host_regex.c` read exactly one shape of pattern — an optionally anchored bracket expression with a repetition count — and refused everything else. That was the right instinct about not guessing, and the wrong subset: of the nine patterns the framework actually compiles, it accepted one.

Here is what a single NVDA startup looks like on the leopard-speech add-on today (trimmed to the distinct patterns; each recurs on every channel open, so the real count is a few hundred lines per session):

```
^[[:digit:]]{7,}$                                            accepted
^(K|M|G|T|P)B$                                               REFUSED
^[IVXLCDM]{2,}$                                              REFUSED
^[[:upper:]]+&[[:upper:]]+$                                  REFUSED
^[[:digit:]]+ISH$                                            REFUSED
^[[:digit:]]{3}\.[[:digit:]]{3}\.[[:digit:]]{4}$             REFUSED
^([[:upper:]](\.)?)+('(([[:upper:]](\.)?)+)?)?(-…)+('?S)?$   REFUSED
^(([[:digit:]]{1,3}(,[[:digit:]]{3})*)|…)[[:upper:]]+$       REFUSED
^((JAN(UARY)?)|(FEB(RUARY)?)|…|(DEC(EMBER)?))$               REFUSED
```

A refusal is a defined answer — the rule simply never fires — so the cost is not a crash, it is pronunciation. `KB` stays "kay bee", `III` stays "eye eye eye", `SEPT` stays a word, `555.123.4567` is read as three quantities, and `20ISH`, `AT&T`, `1,234MB` and the month abbreviations go unrecognised. Plus a log the user cannot see past.

## What this changes

`tiger_host_regex.c` becomes the engine rather than a reader for one shape: a backtracking matcher over POSIX Extended Regular Expressions — alternation, groups, bracket expressions with named classes, ranges and negation, `*` `+` `?` `{n,m}`, both anchors, `.`, and the backslash escape. That is the whole of ERE bar back references, which ERE does not have, and subexpression reporting, which every call here asks not to have (`REG_NOSUB`).

Kept deliberately:

- **The refusal.** Anything still unparseable is refused exactly as before — said once, never matched. It just now has almost nothing to say.
- **Basic REs are refused, not guessed at.** BRE and ERE disagree about `(`, `{` and `+`; nothing in the framework compiles one, and reading a BRE as an ERE is the failure this file exists to avoid.
- **Nothing is written through `preg`.** Same keyed-table approach, same reason as the comment already there.
- **`regcomp` still returns 0.** A caller that does not check gets the old, proven behaviour; a refused pattern still yields `REG_NOMATCH` from `regexec`.

Added:

- `REG_ICASE` and `REG_NEWLINE` are honoured.
- **A step budget.** Nested repetition can make a backtracking engine take exponential time, and this one runs inside a speech request. The step count is capped at 200k, and a pattern that reaches the cap reports no match rather than stopping the voice. The real patterns settle in well under a thousand steps.
- **The pattern table grows.** It held eight and silently dropped the ninth, which is one fewer than this framework compiles; freed slots are now reused as well.

## Testing

`tiger_host --regex-check`, in the same shape as `--aac-check`:

```
$ ./build/tiger_host.exe --regex-check
regex: 115 cases, 0 failures
```

The 115 cases are every pattern above against words that should and should not match, the ERE constructs (nested groups, alternation, negated and named classes, all four repetition forms, anchors, escapes, an empty-matching body under `*`), the patterns that must still be refused, and a `^(a*)*b$` probe against a non-matching subject to prove the budget holds.

Separately, the engine was differentially fuzzed against another ERE implementation on 24,000 generated pattern/subject pairs across six seeds — **0 mismatches, 0 refusals**.

The leopard-speech suite passes against a real 10.5 tree: **44 passed**. `test_interrupting_does_not_delay_the_next_utterance` fails on my machine, but it fails the same way on an unmodified `leopard_host.exe` (2 of 3 runs) — it is a wall-clock latency assertion and this box is busy. Render output is byte-identical before and after for the long-text case, and per-word render times are unchanged except `1234567`, which drops from 3408 ms to 1852 ms because it is now correctly recognised as a phone number and spelt out rather than read as a quantity.

Built with the repo's own `build.sh` (MSVC 2022, 32-bit, `/LARGEADDRESSAWARE`); no warnings from this file.

---

I came to this from the leopard-speech side — the refusals were filling my NVDA log — but the fix belongs here, and Tiger gets the same engine for free even though its dictionary imports no regex at all.
