### PR TITLE
Name the crash, and let the report reach the log

### DIFF
--- a/src/tiger_host_fault.c
+++ b/src/tiger_host_fault.c
@@ -115,7 +115,68 @@ static int survive_divide_by_zero(EXCEPTION_POINTERS *ep)
     return 1;
 }
 
+/* ---- naming an address that is not in an engine image ------------------ */
+/*
+ * `g_images` holds the Mach-O images and nothing else, so a fault anywhere in
+ * the host's own code printed a bare address and no name.  That includes every
+ * CRT function the shim table hands the engine -- `strlen`, `memcpy`, `strcmp`
+ * -- which is where a crash lands when a stubbed shim answers NULL and the
+ * engine passes that answer straight on.  The report from the field was:
+ *
+ *     tiger_host: CRASHED -- exception c0000005 at 009f5b70
+ *     tiger_host:   reading address 00000000
+ *
+ * Two lines, no name, nothing to look up: an address means nothing without the
+ * base it came from, and the base was not in the report.
+ *
+ * Windows knows it.  The address is inside a loaded module and
+ * `GetModuleHandleEx` will say which one, so the offset becomes an RVA that a
+ * map file resolves -- which turned that report into `strlen + 0x30`, and the
+ * diagnosis with it.
+ */
+static int host_module_for(unsigned addr, char *name, size_t namesz,
+                           unsigned *rva)
+{
+    HMODULE mod = NULL;
+    char path[MAX_PATH];
+    const char *base;
+    if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                            GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                            (LPCSTR)(ULONG_PTR)addr, &mod) || !mod)
+        return 0;
+    if (!GetModuleFileNameA(mod, path, (DWORD)sizeof(path)))
+        return 0;
+    base = strrchr(path, '\\');
+    if (!base) base = strrchr(path, '/');
+    _snprintf(name, namesz, "%s", base ? base + 1 : path);
+    name[namesz - 1] = 0;
+    *rva = addr - (unsigned)(ULONG_PTR)mod;
+    return 1;
+}
+
+/* Every line of a crash report carries the program's own name.
+ *
+ * The driver files anything without that prefix at debug level, and that rule
+ * is right for the loader's ordinary commentary -- several hundred lines an
+ * utterance.  A crash is the one place it is wrong.  It happens once, it costs
+ * the user an utterance, and the lines that say *where* are the entire value
+ * of the report.  Without the prefix the only thing that ever reached a log
+ * was the two lines above; the register dump, the stack walk with symbol
+ * names and the missing-shim tally -- all of it already written, all of it
+ * printed -- went to debug and nobody ever saw them.
+ *
+ * A line assembled from several calls needs the prefix only on its first
+ * fragment: the driver reads whole lines. */
+#define crashf(...) (fprintf(stderr, "tiger_host: "), fprintf(stderr, __VA_ARGS__))
+
 static volatile LONG g_faulted;
+/* Which thread owns the report, so a fault raised *by the reporter* can be
+ * told apart from another engine thread piling in behind it.  See on_fault. */
+static volatile DWORD g_faulting_thread;
+/* Raised only around the two walks below that read addresses nothing has
+ * vouched for.  It is what lets a nested fault be handed to ordinary SEH --
+ * where those walks have an __except waiting -- instead of ending the report. */
+static volatile long g_in_walk;
 
 static LONG CALLBACK on_fault(EXCEPTION_POINTERS *ep)
 {
@@ -131,13 +192,42 @@ static LONG CALLBACK on_fault(EXCEPTION_POINTERS *ep)
     /* Report the first fault only.  The engine runs worker threads and a
      * pacer, and once one of them is wedged the others pile in and bury the
      * one report that mattered. */
-    if (InterlockedExchange(&g_faulted, 1)) { Sleep(INFINITE); }
+    if (InterlockedExchange(&g_faulted, 1)) {
+        /* **A reporter that faults must not park itself.**
+         *
+         * This is a vectored handler, so it sees every fault in the process
+         * first -- including one raised by this function while it is writing
+         * the report.  `Sleep(INFINITE)` on that path hung the host for ever,
+         * which is worse than the crash it was describing: the process never
+         * exits, the driver blocks reading a pipe that will never answer, and
+         * the screen reader goes quiet with half a report and no exit code.
+         *
+         * Reproduced: the frame walk below reads [ebp+0c], finds 53005327
+         * there, and hands it to IsBadReadPtr, which faults.  The report
+         * stopped mid-line and the process sat there until it was killed.
+         *
+         * Inside one of the guarded walks, hand the fault to ordinary SEH:
+         * the walk's own __except ends that section and the rest of the
+         * report -- the stack trace, the missing-shim tally -- still gets
+         * written.  Anywhere else in the reporter there is nothing to catch
+         * it, and leaving it to the default handler risks a WER dialog this
+         * process has no way to dismiss, so end it here instead. */
+        if (GetCurrentThreadId() == g_faulting_thread) {
+            if (g_in_walk) return EXCEPTION_CONTINUE_SEARCH;
+            ExitProcess(3);
+        }
+        /* Another engine thread arriving behind the first: park it so the
+         * report is not interleaved with a second one. */
+        Sleep(INFINITE);
+    }
+    g_faulting_thread = GetCurrentThreadId();
     /* Prefixed with the program's own name, and deliberately so: the driver
      * sends everything this writes to NVDA's log, but files anything without
      * that prefix at debug level -- which is off by default.  A crash report
      * that only appears when the user has already turned on debug logging is
-     * a crash report nobody will ever send.  This line is the one that has to
-     * arrive; the detail below it can follow at whatever level. */
+     * a crash report nobody will ever send.  Every line of the report below
+     * carries it too, through crashf: a crash happens once, and the lines
+     * that say *where* are the reason to write any of this down. */
     fprintf(stderr, "tiger_host: CRASHED -- exception %08x at %08x\n", code, pc);
     printf("\n*** exception %08x at %08x\n", code, pc);
     if (code == EXCEPTION_ACCESS_VIOLATION)
@@ -145,23 +235,38 @@ static LONG CALLBACK on_fault(EXCEPTION_POINTERS *ep)
                ep->ExceptionRecord->ExceptionInformation[0] ? "writing"
                                                             : "reading",
                (unsigned)ep->ExceptionRecord->ExceptionInformation[1]);
-    for (i = 0; i < g_nimages; i++) {
-        image *im = g_images[i];
-        if (pc >= im->lo + im->slide && pc < im->hi + im->slide)
-            fprintf(stderr, "tiger_host:   in %s + 0x%x\n",
-                    im->path, pc - im->slide);
+    {
+        int named = 0;
+        for (i = 0; i < g_nimages; i++) {
+            image *im = g_images[i];
+            if (pc >= im->lo + im->slide && pc < im->hi + im->slide) {
+                fprintf(stderr, "tiger_host:   in %s + 0x%x\n",
+                        im->path, pc - im->slide);
+                named = 1;
+            }
+        }
+        if (!named) {
+            char mname[MAX_PATH];
+            unsigned rva;
+            if (host_module_for(pc, mname, sizeof(mname), &rva))
+                fprintf(stderr, "tiger_host:   in %s + 0x%x -- the host's own "
+                                "code, not the engine's\n", mname, rva);
+            else
+                fprintf(stderr, "tiger_host:   in no loaded module\n");
+        }
     }
-    printf("    eax=%08x ebx=%08x ecx=%08x edx=%08x\n"
-           "    esi=%08x edi=%08x ebp=%08x esp=%08x\n",
+    crashf("    eax=%08x ebx=%08x ecx=%08x edx=%08x\n",
            ep->ContextRecord->Eax, ep->ContextRecord->Ebx,
-           ep->ContextRecord->Ecx, ep->ContextRecord->Edx,
+           ep->ContextRecord->Ecx, ep->ContextRecord->Edx);
+    crashf("    esi=%08x edi=%08x ebp=%08x esp=%08x\n",
            ep->ContextRecord->Esi, ep->ContextRecord->Edi,
            ep->ContextRecord->Ebp, ep->ContextRecord->Esp);
     /* When the pc is not inside any image, the call went through a bad
      * pointer and the interesting thing is the caller's arguments -- the
      * object whose dispatch table we jumped through.  ebp is still the
      * caller's frame, because the callee never got to push its own. */
-    {
+    g_in_walk = 1;
+    __try {
         const unsigned *fp = (const unsigned *)ep->ContextRecord->Ebp;
         int inside = 0, a;
         for (i = 0; i < g_nimages; i++)
@@ -170,7 +275,7 @@ static LONG CALLBACK on_fault(EXCEPTION_POINTERS *ep)
         if (!inside && !IsBadReadPtr(fp, 32)) {
             for (a = 2; a <= 4; a++) {
                 const unsigned *obj = (const unsigned *)fp[a];
-                printf("    [ebp+%02x] = %08x", a * 4, fp[a]);
+                crashf("    [ebp+%02x] = %08x", a * 4, fp[a]);
                 if (!IsBadReadPtr(obj, 4)) {
                     const unsigned *tbl = (const unsigned *)obj[0];
                     printf("  -> first word %08x", obj[0]);
@@ -183,7 +288,12 @@ static LONG CALLBACK on_fault(EXCEPTION_POINTERS *ep)
                 printf("\n");
             }
         }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        printf("\n");
+        crashf("    (the frame walk faulted; that part of the report is "
+               "missing)\n");
     }
+    g_in_walk = 0;
 
     /* A call through a null pointer lands at pc 0 with nothing to name, so the
      * only way to find the caller is to read the return address back off the
@@ -203,10 +313,11 @@ static LONG CALLBACK on_fault(EXCEPTION_POINTERS *ep)
      * The nearest preceding symbol turns "SpeechDictionary + 0xf59" into
      * "SLCartDict::SymtabRead + 0x17", which is the difference between a
      * morning of disassembly and a glance. */
-    {
+    g_in_walk = 1;
+    __try {
         const unsigned *sp = (const unsigned *)ep->ContextRecord->Esp;
         int k;
-        printf("    stack:\n");
+        crashf("    stack:\n");
         for (k = 0; k < 64; k++) {
             unsigned v = sp[k];
             for (i = 0; i < g_nimages; i++) {
@@ -235,19 +346,24 @@ static LONG CALLBACK on_fault(EXCEPTION_POINTERS *ep)
                 base = strrchr(im->path, '/');
                 sym = nearest_symbol(im, v - im->slide, &symaddr);
                 if (sym)
-                    printf("      [esp+%02x] %08x  %s + 0x%x  <- %s + 0x%x\n",
+                    crashf("      [esp+%02x] %08x  %s + 0x%x  <- %s + 0x%x\n",
                            k * 4, v, base ? base + 1 : im->path, v - im->slide,
                            sym, (v - im->slide) - symaddr);
                 else
-                    printf("      [esp+%02x] %08x  %s + 0x%x\n", k * 4, v,
+                    crashf("      [esp+%02x] %08x  %s + 0x%x\n", k * 4, v,
                            base ? base + 1 : im->path, v - im->slide);
                 break;
             }
         }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        crashf("    (the stack walk faulted; that part of the report is "
+               "missing)\n");
     }
+    g_in_walk = 0;
     for (i = 0; i < g_nmissing; i++)
         if (g_missing_hits[i])
-            printf("    shim %6d x %s\n", g_missing_hits[i], g_missing[i]);
+            crashf("    shim %6d x %s -- stubbed out, and the engine "
+                   "called it\n", g_missing_hits[i], g_missing[i]);
     fflush(stdout);
     ExitProcess(3);
     return EXCEPTION_CONTINUE_SEARCH;


### PR DESCRIPTION
A crash report arrived from an NVDA user running leopard-speech — twenty-four crashes in six minutes, every one of them these two lines and nothing else:

```
WARNING - external:synthDrivers.leopardspeech.pump - leopardspeech-host-log:
leopard-speech host: tiger_host: CRASHED -- exception c0000005 at 009f5b70
leopard-speech host: tiger_host:   reading address 00000000
```

There is nothing in that to look up. Three separate things had to be wrong for a crash to come out that quiet, and this fixes all three. **It is diagnostics only — nothing on any path an utterance takes changes.**

## 1. The pc was never going to be named

`g_images` holds the Mach-O images and nothing else, so the `in %s + 0x%x` line only ever fires for a fault inside Apple's code. Every CRT function the shim table hands the engine — `strlen`, `memcpy`, `strcmp` — lives in `tiger_host.exe`, which is exactly where a fault lands when a stubbed shim answers NULL and the engine passes that answer straight on. For those, the report named nothing.

`GetModuleHandleEx` knows. The address is inside a loaded module, and the offset from its base is an RVA a map file resolves.

That is how this report was eventually read, the long way round. The machine had not rebooted since before the crashes, so the image base was still the one those processes used:

```
base  0x009e0000   (constant across processes; per-boot ASLR)
pc    0x009f5b70
RVA   0x00015b70   ->  _strlen + 0x30      (from a /MAP build of 944cb42)
```

The installed binary is byte-identical to a build of `944cb42` apart from the PE timestamp and debug GUID, so the map applies exactly. And the only reference to `_strlen` anywhere in the image is the shim-table entry — MSVC inlines every `strlen` the host itself writes, so there is not one direct call to it in `.text`. **The engine called `strlen(NULL)` through a shim.**

That took most of a day. The reporter could have printed it.

## 2. Everything that identified the caller was at debug level

The register dump, the frame walk, the stack walk with C++ symbol names, the tally of stubbed shims the engine actually called — all of it already written, all of it printed, and all of it through `printf`, so the driver files it at debug for want of the `tiger_host:` prefix.

That rule is right for the loader's ordinary commentary, several hundred lines an utterance. It is wrong for a crash, which happens once and costs the user an utterance. `crashf` puts the name on every line of the report; a line assembled from several calls needs it only on the first fragment, since the driver reads whole lines.

## 3. A reporter that faulted hung the host for ever

`on_fault` is a vectored handler, so it sees a fault raised *by itself*, finds `g_faulted` already set, and `Sleep(INFINITE)`s — on the thread that was writing the report. That is worse than the crash it was describing: the process never exits, the driver blocks reading a pipe that will never answer, and the screen reader goes quiet with half a report and no exit code.

Reproduced rather than reasoned about — the frame walk reads `[ebp+0c]`, finds `53005327` there, hands it to `IsBadReadPtr`, and:

```
tiger_host:     [ebp+0c] = 0410a4b0  -> first word 53005327
                                                              <- stops here, rc=124 after 90s
```

The two speculative walks now have an `__except`, and a nested fault inside one is handed to ordinary SEH so that walk ends and the rest of the report still gets written. Outside them there is nothing to catch it, and leaving it to the default handler risks a WER dialog this process cannot dismiss — so it exits instead.

## What it prints now

Same synthetic fault (a `_strlen` shim rigged to read NULL), every line at warning level, and `rc=3` instead of a hang:

```
tiger_host: CRASHED -- exception c0000005 at 004233dc
tiger_host:   reading address 00000000
tiger_host:   in tiger_host.exe + 0x33dc -- the host's own code, not the engine's
tiger_host:     eax=00000000 ebx=040f2bc6 ecx=040f26b1 edx=04110528
tiger_host:     esi=01eaf940 edi=0410a4b0 ebp=019dc2b8 esp=019dc28c
tiger_host:     (the frame walk faulted; that part of the report is missing)
tiger_host:     stack:
tiger_host:       [esp+00] 040f2bee  SpeechDictionary + 0x2bee  <- __ZN7SLMorphC2EPKcRK10SLPhonemesjj12SLWordTagSet + 0x36
tiger_host:       [esp+20] 04047022  SpeechDictionary + 0x7022  <- __ZN9SLMorph_SC2EPKcjj12SLWordTagSet + 0x14
tiger_host:       [esp+30] 0404705b  SpeechDictionary + 0x705b  <- __ZN9SLMorph_SC2EPKcjj12SLWordTagSet + 0x4d
tiger_host:       [esp+64] 040438bd  SpeechDictionary + 0x38bd  <- __ZN12SLMorphRulesC2Eb + 0xb
```

## Testing

- **10 renders byte-identical to the build before this** — Alex, Vicki, Fred, Bruce, Victoria, Agnes; the abbreviation rules (`5KB`, `1,234MB and 20ISH`, `Mr Smith went to St Louis Ave on Jan 3rd`), an em dash, rates 180–400. Same frame counts, same SHA-256 of the PCM.
- **103 tests pass** in leopard-speech against the real engine (`LEOPARD_TREE` set).
- Tiger's own suite skips its engine tests here for want of a Tiger tree; the 6 that do not, pass.
- Nested-fault recovery verified by injecting a bad read inside the guarded walk: report continues, stack walk still runs, `rc=3`.

## What this does not fix

The underlying `strlen(NULL)` is still open. What is known: the only stubbed shim the engine ever calls in a normal run is `_CFURLCreateDataAndPropertiesFromResource`, and the synthetic stack above puts the caller in `SLMorph::SLMorph(char const*, ...)`, which is suggestive but not the real trace. It did not reproduce here across all 24 voices, rates 1–5000 wpm, pitch −100…+200, both request magics, all five `Boundaries.SilThreshold` values, `TIGER_NO_ABBREV` on and off, 24 cancel-event runs at 0–200 ms into a render, and a few hundred fuzzed utterances. Next time it happens, the report will say where — which is the point of this change.

One unrelated thing noticed in passing, not touched here: a word longer than the 512-byte `bounded` buffer in `sh_regexec` falls through to the unterminated `string`, and `"b" * 511 + "KB"` renders as **1 frame** — silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fmgi7MpYyLtL5NAV1VxUH
