### PR TITLE
Fix: Give SAPI voice generations distinct identities

### DIFF
--- a/sapi/panthera_sapi.cpp
+++ b/sapi/panthera_sapi.cpp
@@ -503,7 +503,11 @@ public:
                                  ph==L"more"?L"0":ph==L"most"?L"5":NULL;
             if(thr)params=std::wstring(L"Boundaries.SilThreshold=")+thr;
         }
-        std::wstring root=token_string(token,L"DataPath"), gen=token_string(token,L"Generation"), voice=token_string(token,L"VoiceName");
+        std::wstring root=token_string(token,L"DataPath"), gen=token_string(token,L"Generation"), voice=token_string(token,L"EngineVoiceName");
+        /* New registrations expose a generation-qualified VoiceName because
+         * some clients incorrectly use it as the token identity.  Old tokens
+         * and the resident test only have VoiceName, so retain that fallback. */
+        if(voice.empty()) voice=token_string(token,L"VoiceName");
         std::wstring tree=root+L"\\"+gen, mt=tree+L"\\Speech\\Synthesizers\\MacinTalk.SpeechSynthesizer\\Contents\\MacOS\\MacinTalk";
         std::wstring sd=tree+L"\\SpeechDictionary.framework\\Versions\\A\\SpeechDictionary", vd=tree+L"\\Speech\\Voices";
         long sapiRate=0;

--- a/sapi/settings.ps1
+++ b/sapi/settings.ps1
@@ -79,12 +79,21 @@ function Add-VoiceTokens([string[]]$SelectedGenerations) {
         $root = $base.CreateSubKey('Software\Microsoft\Speech\Voices\Tokens')
         foreach ($voice in $voices) {
             $name = 'Panthera_{0}_{1}' -f $voice.Generation,($voice.Voice -replace ' ','_')
+            # Some SAPI clients key their voice list by Attributes\Name (or by
+            # the convenient VoiceName value) instead of by the token ID.  A
+            # bare "Alex" therefore made Tiger, Leopard, Snow Leopard and Lion
+            # look like one voice even though their token keys were distinct.
+            # Keep the engine's bundle name separately and make every value an
+            # application might use as an identity generation-qualified.
+            $displayName = '{0} ({1})' -f $voice.Voice,$voice.Label
             $key = $root.CreateSubKey($name)
-            $key.SetValue('',('{0} ({1})' -f $voice.Voice,$voice.Label))
-            $key.SetValue('CLSID',$clsid); $key.SetValue('VoiceName',$voice.Voice)
+            $key.SetValue('',$displayName)
+            $key.SetValue('CLSID',$clsid); $key.SetValue('VoiceName',$displayName)
+            $key.SetValue('EngineVoiceName',$voice.Voice)
             $key.SetValue('Generation',$voice.Generation); $key.SetValue('DataPath',$data)
             $attributes = $key.CreateSubKey('Attributes')
-            $attributes.SetValue('Name',$voice.Voice); $attributes.SetValue('Vendor','Panthera Speech')
+            $attributes.SetValue('Name',$displayName); $attributes.SetValue('Vendor','Panthera Speech')
+            $attributes.SetValue('Version',$voice.Label)
             $attributes.SetValue('Language','409'); $attributes.SetValue('Gender','Neutral')
             $attributes.Dispose(); $key.Dispose()
         }


### PR DESCRIPTION
I was having voice conflicts, because the the SAPI driver did not distinguish different versions of the same voice in every application. This is now fixed, so that each voice plainly identifies which version of Mac OS they come from in the speech control panel and every application you use them with.